### PR TITLE
Fix the failing integration tests for pip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file is used to list changes made in each version of the snu_python
 cookbook.
 
+## 0.2.1 (2018-08-03)
+
+- Fix the failing integration tests for pip
+
 ## 0.2.0 (2018-05-31)
 
 - Add a snu_python_virtualenv resource

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'sysadmin@socrata.com'
 license 'Apache-2.0'
 description 'Installs/configures snu_python'
 long_description 'Installs/configures snu_python'
-version '0.2.0'
+version '0.2.1'
 chef_version '>= 12.14'
 
 source_url 'https://github.com/socrata-cookbooks/snu_python'

--- a/test/integration/default/clis_test.rb
+++ b/test/integration/default/clis_test.rb
@@ -36,7 +36,7 @@ end
 describe command('pip --version') do
   its(:exit_status) { should eq(0) }
   its(:stdout) do
-    r = Regexp.new('^pip [0-9]+\.[0-9]+\.[0-9]+ from ' \
+    r = Regexp.new('^pip [0-9]+\.[0-9]+ from ' \
                    "/usr/local/lib/python#{major_minor2}/dist-packages/pip " \
                    "\\(python #{major_minor2}\\)")
     should match(r)


### PR DESCRIPTION
Pip recently switched to a calendar-based versioning scheme, releasing 18.0,
which broke this regex that expected semver.