### PR TITLE
Temporarily pin pip to 18.0 while 18.1 is broken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the snu_python cookbook.
 
+## 1.0.1 (2018-10-08)
+
+- Temporarily pin pip to 18.0
+
 ## 1.0.0 (2018-07-11)
 
 - Delete all custom resources except snu_python

--- a/libraries/resource/snu_python.rb
+++ b/libraries/resource/snu_python.rb
@@ -46,6 +46,7 @@ class Chef
       def after_created
         %w[3 2].each do |p|
           pyr = declare_resource(:python_runtime, p)
+          pyr.pip_version('18.0')
           pyr.options(package_upgrade: true) if action.include?(:upgrade)
           pyr.action(:nothing)
         end
@@ -60,6 +61,7 @@ class Chef
         action act do
           %w[3 2].each do |py|
             python_runtime py do
+              pip_version '18.0'
               options package_upgrade: true if act == :upgrade
             end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'sysadmin@socrata.com'
 license 'Apache-2.0'
 description 'Installs/configures snu_python'
 long_description 'Installs/configures snu_python'
-version '1.0.0'
+version '1.0.1'
 chef_version '>= 12.14'
 
 source_url 'https://github.com/socrata-cookbooks/snu_python'

--- a/spec/support/cookbooks/resource_test/libraries/resource/python_runtime.rb
+++ b/spec/support/cookbooks/resource_test/libraries/resource/python_runtime.rb
@@ -12,6 +12,7 @@ class Chef
     class PythonRuntime < Resource
       provides :python_runtime
 
+      property :pip_version, String
       property :options, Hash
 
       %i[install uninstall].each do |act|

--- a/spec/unit/resources/snu_python.rb
+++ b/spec/unit/resources/snu_python.rb
@@ -85,7 +85,8 @@ shared_context 'resources::snu_python' do
           %w[3 2].each do |p|
             it "installs Python #{p}" do
               opts = act == 'upgrade' ? { package_upgrade: true } : nil
-              expect(chef_run).to install_python_runtime(p).with(options: opts)
+              expect(chef_run).to install_python_runtime(p)
+                .with(pip_version: '18.0', options: opts)
             end
 
             it "#{act}s the requested Python 3 pip packages" do

--- a/test/fixtures/cookbooks/test/recipes/default.rb
+++ b/test/fixtures/cookbooks/test/recipes/default.rb
@@ -14,6 +14,7 @@ end
 
 python_virtualenv '/opt/myapp' do
   python '3'
+  pip_version '18.0'
 end
 
 python_package 'awscli' do
@@ -30,6 +31,7 @@ end
 
 python_virtualenv '/usr/share/collectd/python' do
   python '2'
+  pip_version '18.0'
 end
 
 pip_requirements '/usr/share/collectd/docker/requirements.txt' do


### PR DESCRIPTION
Hopefully pip is fixed soon but, if it's not, this can be merged to work around
the issue until it is.