### PR TITLE
bug :: fix `:remove` action for Ubuntu 18.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,12 @@ install:
 
 env:
   - SUITE=unit
+  - SUITE=default PLATFORM=ubuntu-1804
   - SUITE=default PLATFORM=ubuntu-1604
   - SUITE=default PLATFORM=ubuntu-1404
   - SUITE=default PLATFORM=debian-9
   - SUITE=default PLATFORM=debian-8
+  - SUITE=remove PLATFORM=ubuntu-1804
   - SUITE=remove PLATFORM=ubuntu-1604
   - SUITE=remove PLATFORM=ubuntu-1404
   - SUITE=remove PLATFORM=debian-9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the snu_python cookbook.
 
+## 1.1.0 (2018-10-22)
+
+- Monkeypatch in Ubuntu 18.04 and pip 18.1 support
+
 ## 1.0.1 (2018-10-08)
 
 - Temporarily pin pip to 18.0

--- a/libraries/helpers/snu_python_debian.rb
+++ b/libraries/helpers/snu_python_debian.rb
@@ -29,7 +29,10 @@ module SnuPythonCookbook
       # e.g. /usr/bin/python3 and uninstalling all the dependencies they pull
       # in without any worries about an autoremove unintentionally killing
       # unrelated packages.
+      # Ubuntu 18.04 fails to :remove due to `python-pip-whl` still being
+      # installed.
       PACKAGES ||= %w[
+        python-pip-whl
         python%<major>s
         python%<major>s-dev
         python%<major>s-minimal

--- a/libraries/helpers/snu_python_debian.rb
+++ b/libraries/helpers/snu_python_debian.rb
@@ -32,7 +32,6 @@ module SnuPythonCookbook
       # Ubuntu 18.04 fails to :remove due to `python-pip-whl` still being
       # installed.
       PACKAGES ||= %w[
-        python-pip-whl
         python%<major>s
         python%<major>s-dev
         python%<major>s-minimal
@@ -43,7 +42,7 @@ module SnuPythonCookbook
         libpython%<major_minor>s-stdlib
         libpython%<major_minor>s-minimal
         libpython%<major_minor>s-dev
-      ].freeze
+      ]
 
       #
       # Build the list of packages for this platform that should be managed.
@@ -53,6 +52,9 @@ module SnuPythonCookbook
       # @return [Array<String>] an array of package names
       #
       def packages_for(python)
+        if node['platform'] == 'ubuntu' && node['platform_version'] == '18.04'
+          PACKAGES.push('python-pip-whl')
+        end
         pkgs = PACKAGES.map do |p|
           format(p,
                  major: python == '2' ? '' : python,

--- a/libraries/poise_python/python_providers/system.rb
+++ b/libraries/poise_python/python_providers/system.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module PoisePython
+  module PythonProviders
+    # Patch in the poise-python fixes for Ubuntu 18.04 currently awaiting
+    # release.
+    class System < Base
+      def install_python
+        install_system_packages
+        return unless node.platform_family?('debian') && \
+                      system_package_name == 'python3.6'
+        opts = options
+        package %w[python3.6-venv python3.6-distutils] do
+          action(:upgrade) if opts['package_upgrade']
+        end
+      end
+
+      def uninstall_python
+        if node.platform_family?('debian') && system_package_name == 'python3.6'
+          package %w[python3.6-venv python3.6-distutils] do
+            action(:purge)
+          end
+        end
+        uninstall_system_packages
+      end
+
+      # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      def system_package_candidates(version)
+        # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+        [].tap do |names|
+          # For two (or more) digit versions.
+          if (match = version.match(/^(\d+\.\d+)/))
+            # Debian style pythonx.y
+            names << "python#{match[1]}"
+            # Amazon style pythonxy
+            names << "python#{match[1].delete('.')}"
+          end
+          # Aliases for 2 and 3.
+          if version == '3' || version.empty?
+            names.concat(
+              %w[python3.7 python37 python3.6 python36 python3.5 python35
+                 python3.4 python34 python3.3 python33 python3.2 python32
+                 python3.1 python31 python3.0 python30 python3]
+            )
+          end
+          if version == '2' || version.empty?
+            names.concat(%w[python2.7 python27 python2.6 python26 python2.5
+                            python25])
+          end
+          # For RHEL and friends.
+          names << 'python'
+          names.uniq!
+        end
+      end
+    end
+  end
+end

--- a/libraries/poise_python/resources/python_package.rb
+++ b/libraries/poise_python/resources/python_package.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module PoisePython
+  module Resources
+    # Patch in the poise-python fixes for pip 18.1 currently awaiting release.
+    module PythonPackage
+      PIP_HACK_SCRIPT = <<-HACK.gsub(/^ {8}/, '')
+        import json
+        import re
+        import sys
+        import pip
+        # Don't use pkg_resources because I don't want to require it before this anyway.
+        if re.match(r'0\\.|1\\.|6\\.0', pip.__version__):
+          sys.stderr.write('The python_package resource requires pip >= 6.1.0, currently '+pip.__version__+'\\n')
+          sys.exit(1)
+        try:
+          from pip.commands import InstallCommand
+          from pip.index import PackageFinder
+          from pip.req import InstallRequirement
+          install_req_from_line = InstallRequirement.from_line
+        except ImportError:
+          # Pip 10 moved all internals to their own package.
+          from pip._internal.commands import InstallCommand
+          from pip._internal.index import PackageFinder
+          try:
+            # Pip 18.1 moved from_line to the constructors
+            from pip._internal.req.constructors import install_req_from_line
+          except ImportError:
+            from pip._internal.req import InstallRequirement
+            install_req_from_line = InstallRequirement.from_line
+        packages = {}
+        cmd = InstallCommand()
+        options, args = cmd.parse_args(sys.argv[1:])
+        with cmd._build_session(options) as session:
+          if options.no_index:
+            index_urls = []
+          else:
+            index_urls = [options.index_url] + options.extra_index_urls
+          finder_options = dict(
+            find_links=options.find_links,
+            index_urls=index_urls,
+            allow_all_prereleases=options.pre,
+            process_dependency_links=options.process_dependency_links,
+            trusted_hosts=options.trusted_hosts,
+            session=session,
+          )
+          if getattr(options, 'format_control', None):
+            finder_options['format_control'] = options.format_control
+          finder = PackageFinder(**finder_options)
+          find_all = getattr(finder, 'find_all_candidates', getattr(finder, '_find_all_versions', None))
+          for arg in args:
+            req = install_req_from_line(arg)
+            found = finder.find_requirement(req, True)
+            all_candidates = find_all(req.name)
+            candidate = [c for c in all_candidates if c.location == found]
+            if candidate:
+              packages[candidate[0].project.lower()] = str(candidate[0].version)
+        json.dump(packages, sys.stdout)
+      HACK
+    end
+  end
+end

--- a/libraries/resource/snu_python.rb
+++ b/libraries/resource/snu_python.rb
@@ -96,7 +96,12 @@ class Chef
                   stdout = shell_out!(
                     "/usr/bin/python#{py} -m pip.__main__ list --format=json"
                   ).stdout
-                  JSON.parse(stdout).map { |pkg| pkg['name'] }
+                  # On Ubuntu 18.04, `pip` would remove before other packages,
+                  # causing it to fail out because `pip` no longer existed to
+                  # remove the libraries, pushing it to the end solves that.
+                  # `pygobject` is a `distutils` package and you can't remove
+                  # those.
+                  JSON.parse(stdout).map { |pkg| pkg['name'] unless %w(pip pygobject).include?(pkg['name']) }.compact.push('pip')
                 end
               )
               python py

--- a/libraries/resource/snu_python.rb
+++ b/libraries/resource/snu_python.rb
@@ -46,7 +46,6 @@ class Chef
       def after_created
         %w[3 2].each do |p|
           pyr = declare_resource(:python_runtime, p)
-          pyr.pip_version('18.0')
           pyr.options(package_upgrade: true) if action.include?(:upgrade)
           pyr.action(:nothing)
         end
@@ -61,7 +60,6 @@ class Chef
         action act do
           %w[3 2].each do |py|
             python_runtime py do
-              pip_version '18.0'
               options package_upgrade: true if act == :upgrade
             end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'sysadmin@socrata.com'
 license 'Apache-2.0'
 description 'Installs/configures snu_python'
 long_description 'Installs/configures snu_python'
-version '1.0.1'
+version '1.1.0'
 chef_version '>= 12.14'
 
 source_url 'https://github.com/socrata-cookbooks/snu_python'
@@ -14,6 +14,5 @@ issues_url 'https://github.com/socrata-cookbooks/snu_python/issues'
 
 depends 'poise-python'
 
-# TODO: 18.04 support should be in the next poise-python after 1.7.0.
-supports 'ubuntu', '< 18.04'
+supports 'ubuntu'
 supports 'debian'

--- a/spec/support/cookbooks/resource_test/libraries/resource/python_runtime.rb
+++ b/spec/support/cookbooks/resource_test/libraries/resource/python_runtime.rb
@@ -12,7 +12,6 @@ class Chef
     class PythonRuntime < Resource
       provides :python_runtime
 
-      property :pip_version, String
       property :options, Hash
 
       %i[install uninstall].each do |act|

--- a/spec/unit/resources/snu_python.rb
+++ b/spec/unit/resources/snu_python.rb
@@ -85,8 +85,7 @@ shared_context 'resources::snu_python' do
           %w[3 2].each do |p|
             it "installs Python #{p}" do
               opts = act == 'upgrade' ? { package_upgrade: true } : nil
-              expect(chef_run).to install_python_runtime(p)
-                .with(pip_version: '18.0', options: opts)
+              expect(chef_run).to install_python_runtime(p).with(options: opts)
             end
 
             it "#{act}s the requested Python 3 pip packages" do

--- a/test/fixtures/cookbooks/test/recipes/default.rb
+++ b/test/fixtures/cookbooks/test/recipes/default.rb
@@ -14,7 +14,6 @@ end
 
 python_virtualenv '/opt/myapp' do
   python '3'
-  pip_version '18.0'
 end
 
 python_package 'awscli' do
@@ -31,7 +30,6 @@ end
 
 python_virtualenv '/usr/share/collectd/python' do
   python '2'
-  pip_version '18.0'
 end
 
 pip_requirements '/usr/share/collectd/docker/requirements.txt' do

--- a/test/integration/default/clis_test.rb
+++ b/test/integration/default/clis_test.rb
@@ -6,7 +6,7 @@ end
 
 describe command('python --version') do
   its(:exit_status) { should eq(0) }
-  its(:stderr) { should match(/^Python 2\.7\.[0-9]+$/) }
+  its(:stderr) { should match(/^Python 2\.7\.[0-9]+/) }
 end
 
 describe file('/usr/bin/pip') do
@@ -60,5 +60,5 @@ end
 
 describe command('/usr/share/collectd/python/bin/python --version') do
   its(:exit_status) { should eq(0) }
-  its(:stderr) { should match(/^Python #{major_minor2}\.[0-9]+$/) }
+  its(:stderr) { should match(/^Python #{major_minor2}\.[0-9]+/) }
 end


### PR DESCRIPTION
Tests for Ubuntu 18.04 were failing due to inconsistencies between previous versions of Ubuntu and 18.04.

* `python-pip-whl` remains as an installed package even after the `:remove` action has successfully completed.

* During the removal process for `pip` libraries.  `pip` would remove itself before removing the rest of the libraries, this would cause an error stating `pip` doesn't exist.  This PR pushes `pip` into the list as the last element.  Additionally, `pygobject` is a `distutils` package and thus cannot be removed.   